### PR TITLE
Add product detail page and simplify code

### DIFF
--- a/frontend/src/Components/Header.js
+++ b/frontend/src/Components/Header.js
@@ -1,10 +1,7 @@
 import React, { Component } from 'react';
-import {
-    Link,
-    withRouter
-} from 'react-router-dom';
-import { Anchor, Grommet, Main, Header, Nav, Tabs, Tab, Box, Button, Heading, Select, TextInput, Footer } from 'grommet'
-import { Login,Home, Favorite, UploadOption, Mail, Phone, Github, HelpOption } from 'grommet-icons'
+import { withRouter } from 'react-router-dom';
+import { Anchor, Header, Nav, Box } from 'grommet'
+import { Login,Home, Favorite, UploadOption } from 'grommet-icons'
     
 class Headers extends Component {
     constructor(props) {

--- a/frontend/src/Components/loginForm.js
+++ b/frontend/src/Components/loginForm.js
@@ -4,28 +4,10 @@ import './Login.css';
 import { Link } from 'react-router-dom';
 import { ACCESS_TOKEN } from '../Constants';
 import { Form, Input, Button, notification } from 'antd';
-import { Anchor, Grommet, Header, Nav, Box } from 'grommet'
-import { Login,Home } from 'grommet-icons'
-const FormItem = Form.Item;
+import { Grommet } from 'grommet';
+import { theme } from "../Constants";
 
-const theme = {
-    "global": {
-      "colors": {
-        "background": {
-          "light": "#ffffff",
-          "dark": "#000000"
-        }
-      },
-      "font": {
-        "family": "-apple-system,\n         BlinkMacSystemFont, \n         \"Segoe UI\", \n         Roboto, \n         Oxygen, \n         Ubuntu, \n         Cantarell, \n         \"Fira Sans\", \n         \"Droid Sans\",  \n         \"Helvetica Neue\", \n         Arial, sans-serif,  \n         \"Apple Color Emoji\", \n         \"Segoe UI Emoji\", \n         \"Segoe UI Symbol\""
-      }
-    },
-    "button": {
-      "extend": [
-        null
-      ]
-    }
-  }
+const FormItem = Form.Item;
 
 class Signin extends Component {
     render() {

--- a/frontend/src/Components/productCell.js
+++ b/frontend/src/Components/productCell.js
@@ -1,0 +1,37 @@
+import React, { Component } from "react";
+import {Anchor} from "grommet";
+
+class ProductCell extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+
+        };
+        this.props = {
+            product: null,
+            key: null,
+        };
+    }
+
+    render() {
+        return (
+            <Anchor
+                href={`http://localhost:3000/product/${this.props.product.id}`}
+                label={this.props.product.name}
+                onClick={
+                    () => {
+                        this.props.history.push({
+                            pathname: `/product/${this.props.product.id}`,
+                            data: {
+                                product: this.props.product,
+                            }
+                        });
+                    }
+                }
+            />
+        );
+    }
+
+}
+
+export default ProductCell;

--- a/frontend/src/Components/productCell.js
+++ b/frontend/src/Components/productCell.js
@@ -16,7 +16,7 @@ class ProductCell extends Component {
     render() {
         return (
             <Anchor
-                href={`http://localhost:3000/product/${this.props.product.id}`}
+                href={`https://beauty-deals.herokuapp.com/product/${this.props.product.id}`}
                 label={this.props.product.name}
                 onClick={
                     () => {

--- a/frontend/src/Components/productCell.js
+++ b/frontend/src/Components/productCell.js
@@ -1,37 +1,33 @@
 import React, { Component } from "react";
 import {Anchor} from "grommet";
+import { withRouter } from 'react-router-dom';
 
 class ProductCell extends Component {
     constructor(props) {
         super(props);
-        this.state = {
-
-        };
         this.props = {
             product: null,
-            key: null,
         };
+    }
+
+    handleClick() {
+        this.props.history.push({
+            pathname: `/product/${this.props.product.id}`,
+            data: {
+                product: this.props.product,
+            }
+        });
     }
 
     render() {
         return (
             <Anchor
-                href={`http://localhost:3000/product/${this.props.product.id}`}
                 label={this.props.product.name}
-                onClick={
-                    () => {
-                        this.props.history.push({
-                            pathname: `/product/${this.props.product.id}`,
-                            data: {
-                                product: this.props.product,
-                            }
-                        });
-                    }
-                }
+                onClick={this.handleClick.bind(this)}
             />
         );
     }
 
 }
 
-export default ProductCell;
+export default withRouter(ProductCell);

--- a/frontend/src/Components/signUpForm.js
+++ b/frontend/src/Components/signUpForm.js
@@ -1,4 +1,3 @@
-
 import React, { Component } from 'react';
 import { signup, checkUsernameAvailability, checkEmailAvailability } from '../util/API';
 import './Signup.css';
@@ -9,29 +8,12 @@ import {
     EMAIL_MAX_LENGTH,
     PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH
 } from '../Constants';
-import { Anchor, Grommet, Main, Header, Nav, Tabs, Tab, Box,Heading, Select, TextInput, Footer } from 'grommet'
-import { Login,Home } from 'grommet-icons'
+import { Grommet } from 'grommet'
 import { Form, Input, Button, notification } from 'antd';
+import { theme } from "../Constants";
+
 const FormItem = Form.Item;
 
-const theme = {
-    "global": {
-      "colors": {
-        "background": {
-          "light": "#ffffff",
-          "dark": "#000000"
-        }
-      },
-      "font": {
-        "family": "-apple-system,\n         BlinkMacSystemFont, \n         \"Segoe UI\", \n         Roboto, \n         Oxygen, \n         Ubuntu, \n         Cantarell, \n         \"Fira Sans\", \n         \"Droid Sans\",  \n         \"Helvetica Neue\", \n         Arial, sans-serif,  \n         \"Apple Color Emoji\", \n         \"Segoe UI Emoji\", \n         \"Segoe UI Symbol\""
-      }
-    },
-    "button": {
-      "extend": [
-        null
-      ]
-    }
-  }
 class SignUpForm extends Component {
     constructor(props) {
         super(props);

--- a/frontend/src/Components/uploadForm.js
+++ b/frontend/src/Components/uploadForm.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { upload } from '../util/API';
-import { MAX_CHOICES, POLL_QUESTION_MAX_LENGTH, POLL_CHOICE_MAX_LENGTH } from '../Constants';
+import { POLL_QUESTION_MAX_LENGTH, POLL_CHOICE_MAX_LENGTH } from '../Constants';
 import './Upload.css';  
 import { Form, Input, Button, Icon, Select, Col, notification } from 'antd';
 const Option = Select.Option;

--- a/frontend/src/Constants/index.js
+++ b/frontend/src/Constants/index.js
@@ -9,6 +9,9 @@ export const MAKEUP_API_URL = ( brand, category ) => {
     else
         return `https://makeup-api.herokuapp.com/api/v1/products.json?brand=${brand}&product_type=${category}`;
 }
+export const MAKEUP_API_BY_ID_URL = ( id ) => {
+    return `https://makeup-api.herokuapp.com/api/v1/products/${id}.json`;
+}
 export const ACCESS_TOKEN = 'accessToken';
 
 export const POLL_LIST_SIZE = 30;
@@ -44,3 +47,22 @@ export const CATEGORIES = [
     "mascara",
     "nail_polish",
 ];
+
+export const theme = {
+    "global": {
+        "colors": {
+            "background": {
+                "light": "#ffffff",
+                "dark": "#000000"
+            }
+        },
+        "font": {
+            "family": "-apple-system,\n         BlinkMacSystemFont, \n         \"Segoe UI\", \n         Roboto, \n         Oxygen, \n         Ubuntu, \n         Cantarell, \n         \"Fira Sans\", \n         \"Droid Sans\",  \n         \"Helvetica Neue\", \n         Arial, sans-serif,  \n         \"Apple Color Emoji\", \n         \"Segoe UI Emoji\", \n         \"Segoe UI Symbol\""
+        }
+    },
+    "button": {
+        "extend": [
+            null
+        ]
+    }
+};

--- a/frontend/src/Pages/favorite.js
+++ b/frontend/src/Pages/favorite.js
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import {
-    Button,
     Table,
     TableHeader,
     TableRow,
@@ -8,35 +7,12 @@ import {
     TableBody,
     Image,
     Box,
-    Grommet, Main, Nav, Tabs, Tab, TextInput,
+    Grommet, Main,
     ResponsiveContext,
-    Anchor,
-    Header,
   } from "grommet";
-import { useHistory } from 'react-router-dom'
+import { theme } from "../Constants";
 
-
-
-const theme = {
-  "global": {
-    "colors": {
-      "background": {
-        "light": "#ffffff",
-        "dark": "#000000"
-      }
-    },
-    "font": {
-      "family": "-apple-system,\n         BlinkMacSystemFont, \n         \"Segoe UI\", \n         Roboto, \n         Oxygen, \n         Ubuntu, \n         Cantarell, \n         \"Fira Sans\", \n         \"Droid Sans\",  \n         \"Helvetica Neue\", \n         Arial, sans-serif,  \n         \"Apple Color Emoji\", \n         \"Segoe UI Emoji\", \n         \"Segoe UI Symbol\""
-    }
-  },
-  "button": {
-    "extend": [
-      null
-    ]
-  }
-}
 const Favorite = () => {
-  const history= useHistory();
   const responsive = useContext(ResponsiveContext);
   return (
     <Grommet full theme={theme}>

--- a/frontend/src/Pages/home.js
+++ b/frontend/src/Pages/home.js
@@ -2,25 +2,7 @@ import React, { Component } from 'react';
 import { Grommet, Main, Box, Button, Heading, Select, TextInput, Footer } from 'grommet'
 import { Mail, Phone, Github, HelpOption } from 'grommet-icons'
 import { BRANDS, CATEGORIES} from "../Constants";
-
-const theme = {
-  "global": {
-    "colors": {
-      "background": {
-        "light": "#ffffff",
-        "dark": "#000000"
-      }
-    },
-    "font": {
-      "family": "-apple-system,\n         BlinkMacSystemFont, \n         \"Segoe UI\", \n         Roboto, \n         Oxygen, \n         Ubuntu, \n         Cantarell, \n         \"Fira Sans\", \n         \"Droid Sans\",  \n         \"Helvetica Neue\", \n         Arial, sans-serif,  \n         \"Apple Color Emoji\", \n         \"Segoe UI Emoji\", \n         \"Segoe UI Symbol\""
-    }
-  },
-  "button": {
-    "extend": [
-      null
-    ]
-  }
-}
+import { theme } from "../Constants";
 
 class HomePage extends Component {
   constructor(props) {

--- a/frontend/src/Pages/productDetail.js
+++ b/frontend/src/Pages/productDetail.js
@@ -1,0 +1,75 @@
+import React, { Component } from "react";
+import {
+    Card,
+    CardHeader,
+    CardBody,
+    CardFooter,
+    Button,
+    Main,
+    Box,
+    List,
+    Grommet,
+    Image,
+} from "grommet";
+import { Favorite, ShareOption } from 'grommet-icons'
+import {getProductById} from "../util/API";
+import { theme } from "../Constants";
+
+class ProductDetail extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            product: {},
+        };
+    }
+
+    componentDidMount() {
+        const id = this.props.match.params.id;
+        getProductById(id)
+            .then(response => {
+                this.setState({
+                    product: response.data,
+                });
+            });
+    }
+
+    render() {
+        console.log(this.props.match.params.id);
+        const product = this.state.product;
+        return (
+            <Grommet full theme={theme}>
+                <Main fill="vertical" flex="grow" overflow="auto">
+                    <Box align="center" justify="start" pad="xlarge" height="large">
+                        <Card>
+                            <CardHeader pad="medium">Product Description {this.props.match.params.id}</CardHeader>
+                            <CardBody pad="medium" direction="row-responsive" justify="center" align="stretch" gap="medium">
+                                <Image src={product.image_link} />
+                                <List
+                                    primaryKey="attribute"
+                                    secondaryKey="value"
+                                    data={[
+                                        { attribute: 'Name', value: product.name },
+                                        { attribute: 'Brand', value: product.brand },
+                                        { attribute: 'Category', value: product.product_type },
+                                        { attribute: 'Suggest Price', value: "$" + product.price },
+                                    ]}
+                                />
+                            </CardBody>
+                            <CardFooter pad={{horizontal: "small"}} background="light-2">
+                                <Button
+                                    icon={<Favorite color="red" />}
+                                    hoverIndicator
+                                />
+                                <Button icon={<ShareOption color="plain" />} hoverIndicator />
+                            </CardFooter>
+                        </Card>
+                    </Box>
+                </Main>
+            </Grommet>
+
+        );
+    }
+
+};
+
+export default ProductDetail;

--- a/frontend/src/Pages/searchResult.js
+++ b/frontend/src/Pages/searchResult.js
@@ -1,35 +1,15 @@
 import React, { Component } from "react";
 import {
-    Button,
     DataTable,
     Text,
     Image,
     Box,
-    Grommet, Main, Nav, TextInput,
-    Anchor,
-    Header,
+    Grommet,
+    Main,
   } from "grommet";
-import { Favorite,Login,Home } from "grommet-icons";
 import {getSearchResult} from "../util/API";
-
-const theme = {
-  "global": {
-    "colors": {
-      "background": {
-        "light": "#ffffff",
-        "dark": "#000000"
-      }
-    },
-    "font": {
-      "family": "-apple-system,\n         BlinkMacSystemFont, \n         \"Segoe UI\", \n         Roboto, \n         Oxygen, \n         Ubuntu, \n         Cantarell, \n         \"Fira Sans\", \n         \"Droid Sans\",  \n         \"Helvetica Neue\", \n         Arial, sans-serif,  \n         \"Apple Color Emoji\", \n         \"Segoe UI Emoji\", \n         \"Segoe UI Symbol\""
-    }
-  },
-  "button": {
-    "extend": [
-      null
-    ]
-  }
-}
+import ProductCell from "../Components/productCell";
+import { theme } from "../Constants";
 
 const columns = [
     {
@@ -47,6 +27,11 @@ const columns = [
         property: 'name',
         header: <Text>Name</Text>,
         primary: true,
+        render: data => (
+            <ProductCell
+                product={data}
+            />
+        )
     },
     {
         property: 'brand',

--- a/frontend/src/app/App.js
+++ b/frontend/src/app/App.js
@@ -4,36 +4,19 @@ import {
   Switch,
   withRouter,
 } from 'react-router-dom';
-import { Grommet, Box } from 'grommet'
-import HomePage from "../Pages/home"
-import SearchResult from '../Pages/searchResult';
+import { Grommet, Box } from 'grommet';
 import SignUpForm from '../Components/signUpForm';
 import Signin from '../Components/loginForm';
 import Upload from '../Components/uploadForm';
-import Headers from '../Components/Header'
-import Favorite from '../Pages/favorite'
+import Headers from '../Components/Header';
+import HomePage from "../Pages/home";
+import SearchResult from '../Pages/searchResult';
+import ProductDetail from "../Pages/productDetail";
+import Favorite from '../Pages/favorite';
 import { getCurrentUser } from '../util/API';
 import { ACCESS_TOKEN } from '../Constants';
 import { notification } from 'antd';
-
-const theme = {
-  "global": {
-    "colors": {
-      "background": {
-        "light": "#ffffff",
-        "dark": "#000000"
-      }
-    },
-    "font": {
-      "family": "-apple-system,\n         BlinkMacSystemFont, \n         \"Segoe UI\", \n         Roboto, \n         Oxygen, \n         Ubuntu, \n         Cantarell, \n         \"Fira Sans\", \n         \"Droid Sans\",  \n         \"Helvetica Neue\", \n         Arial, sans-serif,  \n         \"Apple Color Emoji\", \n         \"Segoe UI Emoji\", \n         \"Segoe UI Symbol\""
-    }
-  },
-  "button": {
-    "extend": [
-      null
-    ]
-  }
-}
+import { theme } from "../Constants";
 
 class App extends Component {
   constructor(props) {
@@ -119,6 +102,8 @@ class App extends Component {
                          render={(props) => <Signin onLogin={this.handleLogin} {...props} />}
                   ></Route>
                   <Route path="/upload" component={Upload} ></Route>
+                  <Route exact path="/product" component={ProductDetail} />
+                  <Route exact path="/product/:id" component={ProductDetail} />
                 </Switch>
               
             </Box>

--- a/frontend/src/util/API.js
+++ b/frontend/src/util/API.js
@@ -1,4 +1,4 @@
-import { API_BASE_URL, ACCESS_TOKEN, MAKEUP_API_URL } from '../Constants';
+import {API_BASE_URL, ACCESS_TOKEN, MAKEUP_API_URL, MAKEUP_API_BY_ID_URL} from '../Constants';
 import axios from 'axios';
 
 const request = (options) => {
@@ -74,4 +74,8 @@ export function getCurrentUser() {
 
 export function getSearchResult(brand, category) {
     return axios.get(MAKEUP_API_URL(brand, category));
+}
+
+export function getProductById(id) {
+    return axios.get(MAKEUP_API_BY_ID_URL(id));
 }


### PR DESCRIPTION
- Add product detail page for each product by product id, showing the product's name, brand, category, description and suggested price, etc.
- Simply code by removing unnecessary imports, and moving `theme` to `Constant`

![image](https://user-images.githubusercontent.com/73202843/100050104-98cc3f00-2dcd-11eb-9477-593ff1133339.png)
